### PR TITLE
Homework4

### DIFF
--- a/kubernetes_manifests/README.md
+++ b/kubernetes_manifests/README.md
@@ -2,3 +2,4 @@ k8s pods for online_inference app
 
 * probes.yaml checks the liveliness and readiness of the app, so the original app was modified to shut down
   after one minute and starts with a 20 seconds delay
+* I used shutting down example from [here](https://github.com/encode/uvicorn/issues/742)

--- a/kubernetes_manifests/README.md
+++ b/kubernetes_manifests/README.md
@@ -1,0 +1,4 @@
+k8s pods for online_inference app
+
+* probes.yaml checks the liveliness and readiness of the app, so the original app was modified to shut down
+  after one minute and starts with a 20 seconds delay

--- a/kubernetes_manifests/online-inference-deployment-blue-green.yaml
+++ b/kubernetes_manifests/online-inference-deployment-blue-green.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: anyago/online_inference:v1
+          name: online-inference
+          ports:
+            - containerPort: 8000

--- a/kubernetes_manifests/online-inference-deployment-rolling-update.yaml
+++ b/kubernetes_manifests/online-inference-deployment-rolling-update.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: anyago/online_inference:v1
+          name: online-inference
+          ports:
+            - containerPort: 8000

--- a/kubernetes_manifests/online-inference-pod-probes.yaml
+++ b/kubernetes_manifests/online-inference-pod-probes.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference-probes
+  labels:
+    app: online-inference-probes
+spec:
+  containers:
+    - name: online-inference-probes
+      image: anyago/online_inference:v2
+      ports:
+        - containerPort: 8000
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 80
+        periodSeconds: 10

--- a/kubernetes_manifests/online-inference-pod-resources.yaml
+++ b/kubernetes_manifests/online-inference-pod-resources.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference-resources
+  labels:
+    app: online-inference-resources
+spec:
+  containers:
+    - image: anyago/online_inference:v1
+      name: online-inference-resources
+      ports:
+        - containerPort: 8000
+      resources:
+        requests:
+          memory: "125Mi"
+          cpu: "250m"
+        limits:
+          memory: "10Gi"
+          cpu: "500m"

--- a/kubernetes_manifests/online-inference-pod.yaml
+++ b/kubernetes_manifests/online-inference-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: anyago/online_inference:v1
+      name: online-inference
+      ports:
+        - containerPort: 8000

--- a/kubernetes_manifests/online-inference-replicaset.yaml
+++ b/kubernetes_manifests/online-inference-replicaset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - name: online-inference
+          image: anyago/online_inference:v1
+          ports:
+            - containerPort: 8000

--- a/online_inference/Dockerfile
+++ b/online_inference/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR .
 
 ENV PATH_TO_MODEL="/model.pkl"
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["python", "app.py"]


### PR DESCRIPTION
1) Разверните kubernetes: развернула на гуглооблаке (+5)
2) Напишите простой pod manifests для вашего приложения, назовите его online-inference-pod.yaml (+4)
<img width="455" alt="Screenshot 2021-06-17 at 19 37 50" src="https://user-images.githubusercontent.com/25647155/122767572-b77ab180-d29a-11eb-95dd-c09e0dd07ea8.png">

2а) Пропишите requests/limits и напишите зачем это нужно в описание PR
закоммитьте файл online-inference-pod-resources.yaml (+2) 

**Одна из фишек kubernetes в том, что он сам распределит правильно ресурсы так, чтобы всем подам хватало. Поэтому мы указываем сколько ресурсов хотим получить под контейнер и гарантированно их получим. Лимит означает, что больше чем это значение памяти или cpu выделено не будет.**

3) Модифицируйте свое приложение так, чтобы оно стартовало не сразу(с задержкой секунд 20-30) и падало спустя минуты работы. 
Добавьте liveness и readiness пробы , посмотрите что будет происходить.
Напишите в описании -- чего вы этим добились.
Закоммититьте отдельный манифест online-inference-pod-probes.yaml (и изменение кода приложения)
Опубликуйте ваше приложение(из ДЗ 2) с тэгом v2 (+3)

**Liveness проверяет не умерло ли приложение и если умерло, то пытается перезагрузить. Readiness проверяет готово ли приложение для запросов. Например, оно может подгружать какие-то данные и нам нужно только подождать и readiness проба как раз этим и занята.**

4) Создайте replicaset, сделайте 3 реплики вашего приложения. (https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)

Ответьте на вопрос, что будет, если сменить докер образа в манифесте и одновременно с этим 
а) уменьшить число реплик
б) увеличить число реплик.
Поды с какими версиями образа будут внутри будут в кластере?
(3 балла)
Закоммитьте online-inference-replicaset.yaml (+3)

**Все старые реплики будут хранить старые версии приложения, а созданные новые подгрузятся с последней версией.**

5) Опишите деплоймент для вашего приложения.  (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
Играя с параметрами деплоя(maxSurge, maxUnavaliable), добейтесь ситуации, когда при деплое новой версии 
a) Есть момент времени, когда на кластере есть как все старые поды, так и все новые (опишите эту ситуацию) (закоммититьте файл online-inference-deployment-blue-green.yaml)
б) одновременно с поднятием новых версии, гасятся старые (закоммитите файл online-inference-deployment-rolling-update.yaml) (+3)

**В первом случае запускаются все новые реплики и когда они станут готовы, то старые реплики умрут, но в начальный момент они все есть на кластере. Во втором случае реплики подключаются по одной и вслед за ними по одной выключаются старые.**

Самооценка: потенциально 20